### PR TITLE
refactor: Replace npm with pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ A [Github Action](https://github.com/actions) for creating a new [VisWiz.io](htt
 ## Usage
 
 1. Create a [VisWiz.io](https://www.viswiz.io/) account.
-2. Grab your VisWiz.io [API key](https://app.viswiz.io/account) and save it to your GitHub repository’s **Settings → Secrets**.
-2. Create a VisWiz.io project and grab the project's ID, and optionally save it to your GitHub repository’s **Settings → Secrets**.
+2. Copy your VisWiz.io [API key](https://app.viswiz.io/account) and save it to your GitHub repository’s **Settings → Secrets**.
+2. Create a VisWiz.io project and copy the project's ID.
 
 For example, the following workflow creates a new Buildkite build on every commit:
 
@@ -17,7 +17,7 @@ For example, the following workflow creates a new Buildkite build on every commi
   with:
     api-key: ${{ secrets.VISWIZ_API_KEY }}
     images-directory: ./output/
-    project-id: ${{ secrets.VISWIZ_PROJECT_ID }}
+    project-id: $VISWIZ_PROJECT_ID
 ```
 
 ## Inputs

--- a/action.yaml
+++ b/action.yaml
@@ -34,37 +34,29 @@ runs:
         fi
 
         echo "branch_name=${BRANCH_NAME##refs/heads/}" >> $GITHUB_OUTPUT
-        echo "commit_message=$(git log --format=%B -n 1 $COMMIT_SHA)" >> $GITHUB_OUTPUT
+        echo "commit_message=$(git log --format=%s -n 1 $COMMIT_SHA)" >> $GITHUB_OUTPUT
         echo "commit_sha=$COMMIT_SHA" >> $GITHUB_OUTPUT
         echo "viswiz_version=2" >> $GITHUB_OUTPUT
       shell: bash
       id: vars
 
+    - uses: pnpm/action-setup@v2
+      with:
+        version: 8
+
     - uses: actions/setup-node@v3
+      id: setup-node
       with:
         node-version: '18'
-
-    - run: echo "dir=$(npm config get cache)" >> ${GITHUB_OUTPUT}
-      shell: bash
-      id: npm-cache
-
-    - uses: actions/cache@v3
-      with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-viswiz-${{ steps.vars.outputs.viswiz_version }}
-
-    - run: |
-        echo "::group::Installing viswiz CLI"
-        npm install viswiz@${{ steps.vars.outputs.viswiz_version }}
-        echo "::endgroup::"
-      shell: bash
 
     # https://stackoverflow.com/a/42636741
     - run: |
         echo "::group::Creating new viswiz build"
 
+        pnpm -v
+
         exec {stdout_copy}>&1
-        OUTPUT=$(npm exec viswiz -- build \
+        OUTPUT=$(pnpm dlx viswiz@${{ steps.vars.outputs.viswiz_version }} build \
           --branch "${{ steps.vars.outputs.branch_name }}" \
           --image-dir "${{ inputs.images-directory }}" \
           --message "${{ steps.vars.outputs.commit_message }}" \


### PR DESCRIPTION
This PR replaces the internal usage of `npm` with `pnpm`.

This will not affect what package manager the parent repository is using.